### PR TITLE
chore(default-message): add additional space before port

### DIFF
--- a/controller-esp-idf/main/main.cpp
+++ b/controller-esp-idf/main/main.cpp
@@ -35,7 +35,7 @@ extern "C" void app_main(void) {
 
   char message[101]; // max length you’ll need +1
   auto ownIp = getOwnIp();
-  sprintf(message, "nc %s 23", ownIp);
+  sprintf(message, "nc %s  23", ownIp);
   display.drawString(message, 0, 0);
   ESP_LOGI("main", "%s", message);
 


### PR DESCRIPTION
This helps the users to better understand what to enter. Previously the text was 'nc 192.168.4.1 23' which was construed like 'nc 192.168.4.123'